### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ export default class CrossfadeImage extends Component {
             if (!this.timeout) clearTimeout(this.timeout);
             this.timeout = setTimeout(
               () => this.setState({ bottomOpacity: 0 }),
-              50
+              20
             );
           }
         )

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ export default class CrossfadeImage extends Component {
             if (!this.timeout) clearTimeout(this.timeout);
             this.timeout = setTimeout(
               () => this.setState({ bottomOpacity: 0 }),
-              10
+              50
             );
           }
         )


### PR DESCRIPTION
Increasing timeout up to 50ms helps to stop buggy behaviour in Firefox, where sometimes crossfade effect is not done.