### PR TITLE
Add optional class to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Duration of the delay before fading, in ms - default to 0
 ### style
 Custom styling for the image - default to { maxWidth: '100%', maxHeight: '100%' } for responsive image scaling
 
+### containerClass
+
+Custom class string for the container element - default to 'CrossfadeImage'
+
 ## License
 MIT
 

--- a/index.js
+++ b/index.js
@@ -34,10 +34,10 @@ export default class CrossfadeImage extends Component {
     }
   }
   render() {
-    const { duration, timingFunction, delay, style, alt } = this.props;
+    const { containerClass, duration, timingFunction, delay, style, alt } = this.props;
     const { topSrc, bottomOpacity, bottomSrc } = this.state;
     return (
-      <div style={{ ...defaultStyle, ...{ position: "relative" } }}>
+      <div className={containerClass} style={{ ...defaultStyle, ...{ position: "relative" } }}>
         {topSrc &&
           <img
             style={{ ...defaultStyle, ...style, ...{ position: "absolute" } }}
@@ -69,11 +69,13 @@ CrossfadeImage.propTypes = {
   duration: PropTypes.number,
   timingFunction: PropTypes.string,
   delay: PropTypes.number,
-  style: PropTypes.object
+  style: PropTypes.object,
+  containerClass: PropTypes.string,
 };
 
 CrossfadeImage.defaultProps = {
   duration: 500,
   timingFunction: "ease",
-  delay: 0
+  delay: 0,
+  containerClass: "CrossfadeImage",
 };


### PR DESCRIPTION
Addressing #8 
Added an optional `containerClass` prop to allow the container to receive the same class as other containers in a project. The idea is to improve usability in larger projects